### PR TITLE
Update Sequelize sync option to prevent data loss

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ app.use("/api/v1", routes);
 const PORT = process.env.PORT || 3000;
 
 sequelize
-  .sync({ alter: true })
+  .sync({ force: false })
   .then(() => {
     app.listen(PORT, () => {
       console.log(`Server is running on port ${PORT}`);


### PR DESCRIPTION
Changes the Sequelize synchronization option from 'alter' to 'force' to avoid potential data loss during development.

This adjustment ensures that database changes are applied without dropping existing data, enhancing stability during local development.